### PR TITLE
always load the openssl extension

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -571,7 +571,8 @@ composer-lock-sha = "sha-from-composer-lock"
 			contents, err := os.ReadFile(filepath.Join(workingDir, ".php.ini.d", "composer-extensions.ini"))
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(string(contents)).To(Equal(`extension = hello.so
+			Expect(string(contents)).To(Equal(`extension = openssl.so
+extension = hello.so
 extension = bar.so
 `))
 		})
@@ -610,7 +611,7 @@ extension = bar.so
 			Expect(output).To(ContainSubstring(fmt.Sprintf("Listing files in %s:", filepath.Join(layersDir, composer.ComposerPackagesLayerName, "vendor"))))
 			Expect(output).To(ContainSubstring(" Generating SBOM"))
 			Expect(output).To(ContainSubstring("Running 'composer check-platform-reqs'"))
-			Expect(output).To(ContainSubstring("Found extensions 'hello, bar'"))
+			Expect(output).To(ContainSubstring("Found extensions 'openssl, hello, bar'"))
 		})
 	})
 

--- a/integration/with_extensions_test.go
+++ b/integration/with_extensions_test.go
@@ -67,7 +67,7 @@ func testWithExtensions(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).ToNot(HaveOccurred(), logs.String)
 
 			Expect(logs).To(ContainSubstring("Running 'composer check-platform-reqs'"))
-			Expect(logs).To(ContainSubstring("Found extensions 'fileinfo, gd, mysqli, zip'"))
+			Expect(logs).To(ContainSubstring("Found extensions 'openssl, fileinfo, gd, mysqli, zip'"))
 
 			container, err = docker.Container.Run.
 				WithEnv(map[string]string{"PORT": "8765"}).
@@ -78,6 +78,7 @@ func testWithExtensions(t *testing.T, context spec.G, it spec.S) {
 			// Note that `mbstring` is not included, since it is not available in `php-dist` for unknown reasons
 			extensionsMatcher := And(
 				ContainSubstring("zip"),
+				ContainSubstring("openssl"),
 				ContainSubstring("gd"),
 				ContainSubstring("fileinfo"),
 				ContainSubstring("mysqli"),


### PR DESCRIPTION
This should fix potentially missing openssl extensions (reported in https://github.com/paketo-buildpacks/composer/issues/27). The fix is to always load openssl.so.